### PR TITLE
Fixing Redirect to trait.OwnerRpc.html in Index.html of the Root Dir

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta http-equiv="refresh" content="0;URL=grin_wallet_api/trait.OwnerRpcS.html">
+    <meta http-equiv="refresh" content="0;URL=grin_wallet_api/trait.OwnerRpc.html">
 </head>
 <body>
-    <p>Redirecting to <a href="grin_wallet_api/trait.OwnerRpcS.html">grin_wallet_api/trait.OwnerRpcS.html</a>...</p>
-    <script>location.replace("grin_wallet_api/trait.OwnerRpcS.html" + location.search + location.hash);</script>
+    <p>Redirecting to <a href="grin_wallet_api/trait.OwnerRpc.html">grin_wallet_api/trait.OwnerRpc.html</a>...</p>
+    <script>location.replace("grin_wallet_api/trait.OwnerRpc.html" + location.search + location.hash);</script>
 </body>
 </html>
 


### PR DESCRIPTION
Fixing Redirect to trait.OwnerRpc.html instead of trait.OwnerRpcS.html (in the Index.html in the Root which was created to prevent an empty root which would be generated like that by Rust) 

Also this PR is to test if this will trigger a re-build of the Static Webpage hosted by Git Pages. 
If that's the case this would be an easy workflow to get stuff Released if something new would be added. 